### PR TITLE
updates Dockerfile; fixes ubuntu version: 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu
+FROM ubuntu:20.04
 
 # File Author (Mauricio Moldes) / Maintainer
 MAINTAINER Manuel Rueda <manuel.rueda@cnag.crg.eu>
 
+ENV DEBIAN_FRONTEND=noninteractive
 # Build env 
 RUN apt-get update && \
     apt-get -y install apt-utils wget bzip2 git cpanminus perl-doc gcc make libbz2-dev zlib1g-dev libncurses5-dev libncursesw5-dev liblzma-dev libcurl4-openssl-dev pkg-config libssl-dev aria2 unzip jq vim sudo default-jre python3-pip && \


### PR DESCRIPTION
fix issue with docker build; version jammy (latest) was throwing errors.
Last known good version was 20.04, and it apparently still works.

also:
  adds DEBIAN_FRONTEND=noninteractive env var
  which means apt wont ask the user any questions.